### PR TITLE
This closes #11 and openalea/openalea-recipes#54

### DIFF
--- a/src/openalea/deploy/util.py
+++ b/src/openalea/deploy/util.py
@@ -285,7 +285,7 @@ def is_conda_env():
     The CONDA_ENVPATH environment variable is set by the activate conda script.
     """
 
-    return ('CONDA_ENV_PATH' in os.environ)
+    return ('CONDA_PREFIX' in os.environ)
 
 
 def get_metadata(name):


### PR DESCRIPTION
Replace CONDA_ENV_PATH by CONDA_PREFIX
The CONDA_ENV_PATH variable has been removed from conda activate script (see conda/conda#2312).