### PR TITLE
Build with sconsx in conda env rather than in build-scons dirs

### DIFF
--- a/src/openalea/deploy/command.py
+++ b/src/openalea/deploy/command.py
@@ -376,7 +376,7 @@ class scons(Command):
                      'External parameters to pass to scons.'),
                     ('scons-path=',
                      None,
-                     'Optional scons executable path. eg : C:\Python27\scons.bat for windows.')]
+                     'Optional scons executable path. eg : C:\Python27\scons.bat for windows.'),]
 
     def initialize_options(self):
         self.outfiles = None
@@ -385,6 +385,7 @@ class scons(Command):
         self.build_dir = None  # build directory
         self.scons_ext_param = None  # scons external parameters
         self.scons_path = None
+        self.scons_install = None # install in conda env
 
     def finalize_options(self):
 
@@ -397,6 +398,12 @@ class scons(Command):
 
         if (not self.scons_parameters):
             self.scons_parameters = ""
+
+        if not self.scons_install:
+            if is_conda_env():
+                self.scons_install = True
+
+
 
         self.set_undefined_options('build_ext',
                                    ('build_lib', 'build_dir'),
@@ -436,6 +443,14 @@ class scons(Command):
 
                 # External parameters (from the command line)
                 externp = self.scons_ext_param
+
+                # Install in the conda prefix
+                if self.scons_install:
+                    print "Run SCONS install in conda environment"
+
+                    prefix = conda_prefix()
+                    externp += 'build_libdir=%s/lib build_bindir=%s/bin build_includedir=%s/include'%(prefix, prefix, prefix)
+
 
                 if (self.scons_path):
                     command = self.scons_path
@@ -747,6 +762,7 @@ class alea_install(old_easy_install):
 
     def set_system(self):
         """ Set environment """
+
         if ("win32" in sys.platform):
             # install pywin32
             try:
@@ -822,6 +838,7 @@ def set_env(dyn_lib=None):
     if condaenv:
         # print "CONDA Environment Detected. set_env do something:", dyn_lib
         dyn_lib = install_lib.install_lib(dyn_lib)
+
         # print list(get_all_lib_dirs(precedence=DEV_DIST))
         return
 


### PR DESCRIPTION
On extension (c++) packages, openAlea.Deploy uses SConsX to build a package.
First, it creates a build-scons dir, and copy every build results in it (lib, bin, include).
To allow path relocation et al., just write by default bin, include and libs in conda env.
During the conda build process, everything will be copied in the build env.
The behavior will have an impact mainly when building on a local computer.

So we recommend to not build package in the same env that you use for running it.