### PR TITLE
Fix encoding error in get_repo_list

### DIFF
--- a/src/openalea/deploy/util.py
+++ b/src/openalea/deploy/util.py
@@ -261,7 +261,7 @@ def get_repo_list():
 
     except Exception as e:
         print (e)
-        return [OPENALEA_PI]
+        return [OPENALEA_PI.encode()]
 
 
 def get_recommended_prefix():


### PR DESCRIPTION
Encodes the returned string to bytes in utils.get_repo_list() if an exception occurred when opening OPENALEA_REPOLIST url.

The error currently occurs, the server **openalea.gforge.inria.fr** may be down, is that an issue to fix ?