### PR TITLE
Fix openalea namespace

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup_kwds = dict(
     license='cecill-c',
     zip_safe=False,
 
-    packages=find_namespace_packages(where='src', include=['openalea', 'openalea.*']),
+    packages=find_namespace_packages(where='src', include=['openalea.*']),
     #namespace_packages=['openalea'],
     package_dir={'': 'src'},
     entry_points={},

--- a/src/openalea/deploy/version.py
+++ b/src/openalea/deploy/version.py
@@ -7,7 +7,7 @@ major = 3
 minor = 1
 """(int) Version minor component."""
 
-post = 0
+post = 1
 """(int) Version post or bugfix component."""
 
 __version__ = ".".join([str(s) for s in (major, minor, post)])


### PR DESCRIPTION
Replace 
```python
find_namespace_packages(where='src', include=['openalea', 'openalea.*'])
```
by 
```python
find_namespace_packages(where='src', include=['openalea.*'])
```